### PR TITLE
Fix bug on mediamanager with virtual host farm

### DIFF
--- a/inc/farm.php
+++ b/inc/farm.php
@@ -68,6 +68,9 @@ function farm_confpath($farm) {
             if(is_dir("$farm/$dir/conf/")) {
                 if(!defined('DOKU_FARM')) define('DOKU_FARM', 'virtual');
                 return "$farm/$dir/conf/";
+            } else if (is_dir(dirname(__FILE__)."/../$farm/$dir/conf/")) {
+                if(!defined('DOKU_FARM')) define('DOKU_FARM', 'virtual');
+                return dirname(__FILE__)."/../$farm/$dir/conf/";
             }
         }
     }


### PR DESCRIPTION
We have a virtual host based dokuwiki farm with this paths:
- dokuwiki dir: `/var/www/xxx/doku`
- farmdir: `/var/www/xxx/wiki/users`

When uploading files in an animal wiki, the files go in `/var/www/xxx/doku/data/media` instead of `/var/www/xxx/wiki/users/animal.tld/data/media`. And we can't have resized pictures (`{{::cthulhu.jpg?400|}}`): the `tok` parameter isn't good (I guess that the token is supposed to be stored in the animal's `data` directory).

This bug apart, the wikis work as expected (it uses the good animal, stores the pages, has users, etc)

The bug comes from `farm.php` that doesn't find the animal dir (`$farm/$dir/conf/`), and it seems to be related to the fact that `mediamanager.php` is in `lib/exe` (two subdirectories from dokuwiki root), and `farm.php` is in `inc` (only one subdirectory from dokuwiki root).

This patch tries to go up one more directory if the first search for animal configuration directory failed.